### PR TITLE
fix deploy flow to re-roll application with new image

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,22 +79,31 @@ jobs:
 
   deploy:
     needs: push_to_registry
+    name: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: Azure/docker-login@v1
-        with:
-          login-server: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-      - uses: Azure/k8s-set-context@v1
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: kube login
+        uses: Azure/k8s-set-context@v1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.K8S_CONFIG }}
-      - uses: Azure/k8s-deploy@v1.4
+      - name: precheck
+        run: |
+          OUTPUT=$(kubectl rollout status deployment plantbook 2>&1) && echo "::set-output name=OUTPUT::$OUTPUT"
+        continue-on-error: true
+        id: status
+      - name: full deploy
+        if: steps.status.outputs.OUTPUT != 'deployment "plantbook" successfully rolled out'
+        uses: Azure/k8s-deploy@v1.4
         with:
           namespace: 'g1-vladimir'
           manifests: |
             ./deploy/deployment.yml
           images: |
-            ghcr.io/kaatinga/plantbook/restapi:latest
+              ghcr.io/kaatinga/plantbook/restapi:latest
+      - name: re-roll
+        if: steps.status.outputs.OUTPUT == 'deployment "plantbook" successfully rolled out'
+        run: |
+          kubectl delete po -l app=plantbook

--- a/deploy/deployment.yml
+++ b/deploy/deployment.yml
@@ -29,6 +29,7 @@ spec:
                   key: db_url
             - name: PLANTBOOK_HTTPD_PORT
               value: "8081"
+          imagePullPolicy: Always
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
добавил prechek этап в деплой  
  

```
- name: precheck       
  run: |          
      OUTPUT=$(kubectl rollout status deployment plantbook) && echo "::set-output name=OUTPUT::$OUTPUT"                
   continue-on-error: true       
   id: status      
- name: full deploy       
   if: steps.status.outputs.OUTPUT != 'deployment "plantbook" successfully rolled out'
   **ЗАПУСКАЕМ ПОЛНЫЙ ДЕПЛОЙ С НУЛЯ КАК РАНЬШЕ**
<...>
- name: re-roll       
   if: steps.status.outputs.OUTPUT == 'deployment "plantbook" successfully rolled out'   
  **УДАЛЯЕМ ПОД С ПРИЛОЖЕНИЕМ PLANTBOOK И ОН ПЕРЕСОЗДАЁТСЯ С НОВЫМ ОБРАЗОМ
   ДЛЯ ЭТОГО ДОБАВЛЕН ПАРАМЕТР IMAGEPULLPOLICY: ALWAYS В DEPLOYMENT**    
- run: |          
     kubectl delete po -l app=plantbook
```

